### PR TITLE
FIX: attempt a fallback translation key lookup to Translation class

### DIFF
--- a/nstack-kotlin-android/src/main/java/dk/nodes/nstack/kotlin/NStack.kt
+++ b/nstack-kotlin-android/src/main/java/dk/nodes/nstack/kotlin/NStack.kt
@@ -672,7 +672,15 @@ object NStack {
      * Exposed Adders(?)
      */
     private fun getTranslationByKey(key: String?): String? {
-        return currentLanguage?.optString(key?.cleanKeyName ?: return null, null)
+        key?.cleanKeyName ?: return null
+        // Try to find value in our JSON map (from cache or network)
+        return  if(currentLanguage?.has(key.cleanKeyName) == true) {
+            currentLanguage?.optString(key.cleanKeyName)
+        // Find the value in our static Translation class as a fallback
+        // (This should work as this is what the app was built with)
+        } else {
+            classTranslationManager.getFieldValue(key)
+        }
     }
 
     fun addView(view: View, translationData: TranslationData) {

--- a/nstack-kotlin-android/src/main/java/dk/nodes/nstack/kotlin/managers/ClassTranslationManager.kt
+++ b/nstack-kotlin-android/src/main/java/dk/nodes/nstack/kotlin/managers/ClassTranslationManager.kt
@@ -1,6 +1,7 @@
 package dk.nodes.nstack.kotlin.managers
 
 import dk.nodes.nstack.kotlin.util.NLog
+import dk.nodes.nstack.kotlin.util.extensions.cleanKeyName
 import org.json.JSONObject
 
 class ClassTranslationManager {
@@ -51,6 +52,26 @@ class ClassTranslationManager {
             NLog.d("", e.message ?: "")
             NLog.d("ClassTranslationManager", "Error updating field: $key : $value")
         }
+    }
+
+    fun getFieldValue(xmlKey: String): String? {
+        try {
+            var sectionName = xmlKey.cleanKeyName.split("_").firstOrNull() ?: return null
+            val keyName = xmlKey.cleanKeyName.split("_").lastOrNull() ?: return null
+
+            if (sectionName.equals("default", ignoreCase = true)) {
+                sectionName = "defaultSection"
+            }
+
+            val sectionClass = Class.forName(translationClass!!.name + "$" + sectionName)
+            val actualValue = sectionClass.getField(keyName).get(null) as? String
+
+            return actualValue
+        } catch (e: Exception) {
+            NLog.d("", e.message ?: "")
+        }
+
+        return null
     }
 
     companion object {


### PR DESCRIPTION
In the case where there's inconsistencies in various CDN versions of each language in a NStack app, we can end up in a scenario where language returned from NStack **does not contain a key** that the app was built with.

(This is something we're looking into fixing server side, so all languages are published each time)

A fallback is to look at the value in the Translation class, which _should_ contain the an older value, since the app was built with that particular version of Translation.